### PR TITLE
docs: replace install instructions with install-mcp link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a drop-in replacement for the [default fetch MCP server](https://github.
 
 ## Installation
 
-Follow the up-to-date instructions on [install-mcp](https://adamjones.me/install-mcp/?config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImRlZnVkZGxlLWZldGNoLW1jcC1zZXJ2ZXIiXSwibmFtZSI6ImRlZnVkZGxlLWZldGNoIn0=), which generates the right config for your MCP client (Claude Code, Claude Desktop, Cursor, Cline, VS Code, and more).
+Follow the instructions on [install-mcp](https://adamjones.me/install-mcp/?config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImRlZnVkZGxlLWZldGNoLW1jcC1zZXJ2ZXIiXSwibmFtZSI6ImRlZnVkZGxlLWZldGNoIn0=), which generates the right config for your MCP client (Claude Code, Claude Desktop, Cursor, Cline, VS Code, and more).
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -21,21 +21,7 @@ This is a drop-in replacement for the [default fetch MCP server](https://github.
 
 ## Installation
 
-To use this server with the Claude Desktop app, add the following configuration to the "mcpServers" section of your `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "defuddle-fetch": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "defuddle-fetch-mcp-server"
-      ]
-    }
-  }
-}
-```
+Follow the up-to-date instructions on [install-mcp](https://adamjones.me/install-mcp/?config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsImRlZnVkZGxlLWZldGNoLW1jcC1zZXJ2ZXIiXSwibmFtZSI6ImRlZnVkZGxlLWZldGNoIn0=), which generates the right config for your MCP client (Claude Code, Claude Desktop, Cursor, Cline, VS Code, and more).
 
 ## Components
 


### PR DESCRIPTION
Replaces the hand-maintained install instructions with a single link to [install-mcp](https://adamjones.me/install-mcp/) pre-filled for this server, so each client's instructions stay correct without maintaining them here.

Closes domdomegg/computer-use-mcp#77

🤖 Generated with [Claude Code](https://claude.com/claude-code)